### PR TITLE
Lock MySQL to 8.0.31

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:8.0.31
 
 EXPOSE 3306
 


### PR DESCRIPTION
Lock MySQL version to 8.0.31.
https://hub.docker.com/layers/library/mysql/8.0.31/images/sha256-fb3d8639a938515aaac38acb13c4acc061366a20322c55bbedae9d127cd2f2b3?context=explore